### PR TITLE
Move tracker configuration to Pathshare client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## 2.1.0 - 2018-08-30
+### Changed
+- Moved tracking mode configuration to the Pathshare client to use the same config across all sessions
+- Add support for multi-session
+- Minor improvements
+
+## 2.0.0 - 2018-08-20
+### Changed
+- Updated to use our enhanced API
+- Added possibility to invite customer and get a inique inivation URL back
+- Minor improvements
+
+
 ## 1.0.1 - 2017-08-08
 ### Changed
 - Added support for Android 7.x.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ repositories {
 
 dependencies {
     ...
-    compile 'ch.freshbits.pathshare.sdk:pathshare-sdk:2.0.0'
+    compile 'ch.freshbits.pathshare.sdk:pathshare-sdk:2.1.0'
 }
 ```
 
@@ -60,17 +60,26 @@ public class ExampleApplication extends Application {
     public void onCreate() {
         super.onCreate();
 
-        Pathshare.initialize(this, getString(R.string.pathshare_account_token));
+        Pathshare.initialize(this, getString(R.string.pathshare_account_token), TrackingMode.SMART);
     }
 }
 ```
+
+Optionally, you can specify a tracking mode to configure the behavior of the location tracker. The following tracking modes are available:
+
+Tracking Mode      | Description
+-------------------|------------------------------------------------------------
+`SMART`            | Adapts intelligently to the environment and usage of the device. Includes awareness of battery level, travel speed and motion activity.
+`ECO`              | Static mode providing constant tracking data with very low accuracy (several kilometers) and great distance between single locations and ensuring maximum battery life.
+`APPROXIMATE`      | Static mode providing constant tracking data with low accuracy (several hundred meters) and middle distance between single locations. Useful when a low battery drain is a important criteria.
+`ACCURATE`         | Static mode providing constant tracking with the highest accuracy possible (few meters) and small distances between locations. Useful for scenarios where a high accuracy is an essential requirement.
 
 ### Save User
 
 Before creating a session, you need to set a username:
 
 ```java
-Pathshare.client().saveUser("Candice", "+14159495533", UserType.DRIVER, new ResponseListener() {
+Pathshare.client().saveUser("Candice", "+12345678901", UserType.DRIVER, new ResponseListener() {
     @Override
     public void onSuccess() {
         // ...
@@ -99,18 +108,10 @@ To create a session, use the session builder:
 session = new Session.Builder()
     .setExpirationDate(expirationDate)
     .setName("Shopping")
-    .setTrackingMode(TrackingMode.SMART) // optional
     .build();
 ```
 
-A session needs an expiration date and a name. Optionally, you can specify a tracking mode to configure the behavior of the location tracker. The following tracking modes are available:
-
-Tracking Mode      | Description
--------------------|------------------------------------------------------------
-`SMART`            | Adapts intelligently to the environment and usage of the device. Includes awareness of battery level, travel speed and motion activity.
-`ECO`              | Static mode providing constant tracking data with very low accuracy (several kilometers) and great distance between single locations and ensuring maximum battery life.
-`APPROXIMATE`      | Static mode providing constant tracking data with low accuracy (several hundred meters) and middle distance between single locations. Useful when a low battery drain is a important criteria.
-`ACCURATE`         | Static mode providing constant tracking with the highest accuracy possible (few meters) and small distances between locations. Useful for scenarios where a high accuracy is an essential requirement.
+A session needs an expiration date and a name. You can create multiple sessions at the same time, the SDK will manage them for you.
 
 
 Make sure to save the session after building:
@@ -173,7 +174,7 @@ This call will add your Pathshare user to the session and you will be able to se
 To invite a customer to the session, call the `inviteUser()` method on the session object:
 
 ```java
-session.inviteUser("Customer name", UserType.CLIENT, "customer@email.com", "+14159495533", new InvitationResponseListener() {
+session.inviteUser("Customer name", UserType.CLIENT, "customer@email.com", "+12345678901", new InvitationResponseListener() {
     @Override
     public void onSuccess(URL url) {
         // ...

--- a/android-example-app/app/build.gradle
+++ b/android-example-app/app/build.gradle
@@ -8,7 +8,7 @@ android {
         applicationId "ch.freshbits.pathshare.example"
         minSdkVersion 25
         targetSdkVersion 27
-        versionCode 2_0_0
+        versionCode 2_1_0
         versionName "2.1.0"
     }
 

--- a/android-example-app/app/build.gradle
+++ b/android-example-app/app/build.gradle
@@ -9,7 +9,7 @@ android {
         minSdkVersion 25
         targetSdkVersion 27
         versionCode 2_0_0
-        versionName "2.0.0"
+        versionName "2.1.0"
     }
 
     lintOptions {
@@ -40,5 +40,5 @@ dependencies {
     testCompile 'junit:junit:4.12'
     //noinspection GradleCompatible
     compile 'com.android.support:appcompat-v7:27.1.1'
-    compile 'ch.freshbits.pathshare.sdk:pathshare-sdk:2.0.0'
+    compile 'ch.freshbits.pathshare.sdk:pathshare-sdk:2.1.0'
 }

--- a/android-example-app/app/src/main/java/ch/freshbits/pathshare/example/ExampleApplication.java
+++ b/android-example-app/app/src/main/java/ch/freshbits/pathshare/example/ExampleApplication.java
@@ -3,12 +3,13 @@ package ch.freshbits.pathshare.example;
 import android.app.Application;
 
 import ch.freshbits.pathshare.sdk.Pathshare;
+import ch.freshbits.pathshare.sdk.location.TrackingMode;
 
 public class ExampleApplication extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
 
-        Pathshare.initialize(this, getString(R.string.pathshare_account_token));
+        Pathshare.initialize(this, getString(R.string.pathshare_account_token), TrackingMode.SMART);
     }
 }

--- a/android-example-app/app/src/main/java/ch/freshbits/pathshare/example/MainActivity.java
+++ b/android-example-app/app/src/main/java/ch/freshbits/pathshare/example/MainActivity.java
@@ -120,7 +120,6 @@ public class MainActivity extends Activity {
                     .setDestination(destination)
                     .setExpirationDate(expirationDate)
                     .setName("simple session")
-                    .setTrackingMode(TrackingMode.SMART)
                     .setSessionExpirationListener(new SessionExpirationListener() {
                         @Override
                         public void onExpiration() {


### PR DESCRIPTION
The tracking mode can now be configured once on the client object (Pathshare) and will be used across all sessions.