### PR TITLE
Release 2.3.4.post0

### DIFF
--- a/android-example-app/app-kotlin/build.gradle
+++ b/android-example-app/app-kotlin/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
-    id 'kotlin-android-extensions'
 }
 
 android {

--- a/android-example-app/app-kotlin/src/main/AndroidManifest.xml
+++ b/android-example-app/app-kotlin/src/main/AndroidManifest.xml
@@ -11,7 +11,6 @@
         android:theme="@style/AppTheme" >
         <activity
             android:name="ch.freshbits.pathshare.example.MainActivity"
-            android:label="@string/app_name"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/android-example-app/app-kotlin/src/main/java/ch/freshbits/pathshare/example/MainActivity.kt
+++ b/android-example-app/app-kotlin/src/main/java/ch/freshbits/pathshare/example/MainActivity.kt
@@ -1,8 +1,12 @@
 package ch.freshbits.pathshare.example
 
+import android.app.AlarmManager
 import android.content.Context
+import android.content.Intent
 import android.content.SharedPreferences
+import android.os.Build
 import android.os.Bundle
+import android.provider.Settings
 import android.util.Log
 import android.view.View
 import android.widget.Button
@@ -146,10 +150,11 @@ class MainActivity : AppCompatActivity() {
     private fun joinSession() {
         if (session.isExpired) return
 
-        if (hasLocationPermission()) {
+        if (hasLocationPermission() && hasAlarmPermission()) {
             performJoinSession()
         } else {
-            requestLocationPermission()
+            if (!hasLocationPermission()) { requestLocationPermission() }
+            if (!hasAlarmPermission()) { requestAlarmPermission() }
         }
     }
 
@@ -220,6 +225,26 @@ class MainActivity : AppCompatActivity() {
 
     private fun hasLocationPermission(): Boolean {
         return PermissionRequester.hasPermission(this, android.Manifest.permission.ACCESS_FINE_LOCATION)
+    }
+
+    private fun requestAlarmPermission() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            return
+        }
+        val intent = Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM)
+        startActivity(intent)
+    }
+
+    private fun hasAlarmPermission(): Boolean {
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.S || getAlarmManager().canScheduleExactAlarms()
+    }
+
+    private fun getAlarmManager(): AlarmManager {
+        return getContext().getSystemService(ALARM_SERVICE) as AlarmManager
+    }
+
+    private fun getContext(): Context {
+        return Pathshare.client().context
     }
 
     private fun saveSessionIdentifier() {

--- a/android-example-app/app/src/main/java/ch/freshbits/pathshare/example/MainActivity.java
+++ b/android-example-app/app/src/main/java/ch/freshbits/pathshare/example/MainActivity.java
@@ -2,10 +2,14 @@ package ch.freshbits.pathshare.example;
 
 import android.Manifest;
 import android.app.Activity;
+import android.app.AlarmManager;
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.util.Log;
 import android.widget.Button;
 import android.widget.Toast;
@@ -131,10 +135,11 @@ public class MainActivity extends Activity {
     private void joinSession() {
         if (getSession().isExpired()) { return; }
 
-        if (hasLocationPermission()) {
+        if (hasLocationPermission() && hasAlarmPermission()) {
             performJoinSession();
         } else {
-            requestLocationPermission();
+            if (!hasLocationPermission()) { requestLocationPermission(); }
+            if (!hasAlarmPermission()) { requestAlarmPermission(); }
         }
     }
 
@@ -169,6 +174,27 @@ public class MainActivity extends Activity {
 
     private boolean hasLocationPermission() {
         return PermissionRequester.hasPermission(this, Manifest.permission.ACCESS_FINE_LOCATION);
+    }
+
+    private void requestAlarmPermission() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            return;
+        }
+
+        Intent intent = new Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM);
+        startActivity(intent);
+    }
+
+    private boolean hasAlarmPermission() {
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.S || getAlarmManager().canScheduleExactAlarms();
+    }
+
+    private AlarmManager getAlarmManager() {
+        return (AlarmManager) getContext().getSystemService(Context.ALARM_SERVICE);
+    }
+
+    private Context getContext() {
+        return Pathshare.client().getContext();
     }
 
     @Override

--- a/android-example-app/build.gradle
+++ b/android-example-app/build.gradle
@@ -24,6 +24,6 @@ allprojects {
     }
 }
 
-task clean(type: Delete) {
+tasks.register('clean', Delete) {
     delete rootProject.buildDir
 }

--- a/android-example-app/build.gradle
+++ b/android-example-app/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.7.22'
+    ext.kotlin_version = '1.9.22'
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
- Use only `SCHEDULE_EXACT_ALARM` permission
- Bump Kotlin version to `1.9.22`
- Update demo apps to request alarm permission of Android >= 13